### PR TITLE
Extend Duck after composition

### DIFF
--- a/spec/duck.js
+++ b/spec/duck.js
@@ -34,6 +34,13 @@ describe("Duck", function() {
 		expect(duck.hasTalked).toBe(true);
 		expect(sound).toBe("coin coin");
 	});
+
+	it("can quack", function() {
+		var duck = new Duck();
+		expect(duck.hasQuacked).toBe(false);
+		duck.quack();
+		expect(duck.hasQuacked).toBe(true);
+	});
 });
 
 

--- a/src/duck.ts
+++ b/src/duck.ts
@@ -3,9 +3,9 @@ import Swimmer = require("./swimmer");
 import Walker = require("./walker");
 import Talker = require("./talker");
 
-interface Duck extends Swimmer, Walker, Talker {
+interface IDuck extends Swimmer, Walker, Talker {
     // constructor signature the typescript way
-    new(options?:DuckConstructorOptions):Duck;
+    new(options?:DuckConstructorOptions):IDuck;
     (options?:DuckConstructorOptions):void;
 }
 
@@ -13,6 +13,19 @@ interface DuckConstructorOptions {
     sound:string
 }
 
-var Duck:Duck = compose({sound:"coin"}, [Swimmer, Walker, Talker]) as Duck;
+let IDuck = compose({sound:"coin"}, [Swimmer, Walker, Talker]) as IDuck;
+
+// Duck class can add any custom methods
+class Duck extends IDuck {
+    constructor(options: DuckConstructorOptions) {
+        super(options);
+    }
+
+    hasQuacked = false;
+
+    quack() {
+        this.hasQuacked = true;
+    }
+}
 
 export = Duck;

--- a/src/index.ts
+++ b/src/index.ts
@@ -1,17 +1,17 @@
-
 import Duck = require("./duck");
 
 class MyApp {
-    duck:Duck;
+    duck: Duck;
 
     constructor() {
-        this.duck = new Duck({sound:"puiock"});
+        this.duck = new Duck({sound: "puiock"}) as Duck;
     }
 
     manageDuck() {
         this.duck.talk();
         this.duck.swim();
         this.duck.walk();
+        this.duck.quack();
     }
 }
 


### PR DESCRIPTION
Show how the Duck can be extended after composition.  Of course, `.quack()` could have been added in a `Quacker` class and used in composition, however I wanted to show how to extend Duck post-composition for greater flexibility
